### PR TITLE
Adding container registry resource output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_container_registry" "this" {
   location            = var.location
   name                = coalesce(var.container_registry_name, "cr${random_string.acr_suffix.result}")
   resource_group_name = var.resource_group_name
-  sku                 = "Premium"
+  sku                 = var.container_registry_sku != null ? var.container_registry_sku : "Premium"
   tags                = var.tags
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,6 +11,11 @@ output "resource_id" {
   value       = azurerm_kubernetes_cluster.this.id
 }
 
+output "kubernetes_cluster_name" {
+  description = "The name of the Kubernetes cluster."
+  value       = azurerm_kubernetes_cluster.this.name
+}
+
 output "container_registry_resource_id" {
   description = "The `azurerm_container_registry`'s resource id."
   value       = azurerm_container_registry.this.login_server

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,17 +11,12 @@ output "resource_id" {
   value       = azurerm_kubernetes_cluster.this.id
 }
 
-output "kubernetes_cluster_name" {
-  description = "The name of the Kubernetes cluster."
-  value       = azurerm_kubernetes_cluster.this.name
+output "container_registry_resource" {
+  description = "This is the full output for the container registry resource."
+  value       = azurerm_container_registry.this
 }
 
 output "container_registry_resource_id" {
-  description = "The `azurerm_container_registry`'s resource id."
-  value       = azurerm_container_registry.this.login_server
-}
-
-output "container_registry_login_server" {
-  description = "The login server of the container registry."
-  value       = azurerm_container_registry.this.login_server
+  description = "The `azurerm_kubernetes_cluster`'s resource id."
+  value       = azurerm_container_registry.this.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,3 +10,13 @@ output "resource_id" {
   description = "The `azurerm_kubernetes_cluster`'s resource id."
   value       = azurerm_kubernetes_cluster.this.id
 }
+
+output "container_registry_resource_id" {
+  description = "The `azurerm_container_registry`'s resource id."
+  value       = azurerm_container_registry.this.login_server
+}
+
+output "container_registry_login_server" {
+  description = "The login server of the container registry."
+  value       = azurerm_container_registry.this.login_server
+}

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "container_registry_name" {
   description = "(Optional) The name of the container registry to use for the AKS cluster."
 }
 
+variable "container_registry_sku" {
+  type        = string
+  default     = null
+  description = "(Optional) The SKU of the container registry to use for the AKS cluster. If not specified, the default is 'Premium'."
+}
+
 variable "enable_telemetry" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

This module deploys AKS and ACR resources but only returns the resource object and resource ID of the AKS cluster. This PR includes the ACR resource and id as well.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
