### PR TITLE
fix: update load balancer SKU from basic to standard

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "azurerm_kubernetes_cluster" "this" {
   }
   network_profile {
     network_plugin    = "kubenet"
-    load_balancer_sku = "basic"
+    load_balancer_sku = "standard"
     network_policy    = "calico"
   }
 


### PR DESCRIPTION
## Description

load_balancer_sku was hardcoded to "basic" with no way to override it. Azure now rejects basic for AKS with error InvalidLoadBalancerSku, making the module non-functional. 

Reference: [Azure docs — Basic Load Balancer retirement](https://azure.microsoft.com/en-us/updates/azure-basic-load-balancer-will-be-retired-on-30-september-2025/)

Closes #55 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
